### PR TITLE
Axios options reference link corrected

### DIFF
--- a/template/nuxt/nuxt.config.js
+++ b/template/nuxt/nuxt.config.js
@@ -88,7 +88,7 @@ module.exports = {
   ** Axios module configuration
   */
   axios: {
-    // See https://github.com/nuxt-community/axios-module#options
+    // See https://axios.nuxtjs.org/options
   },<% } %>
 
   /*


### PR DESCRIPTION
Changed axios options reference link from https://github.com/nuxt-community/axios-module#options' to https://axios.nuxtjs.org/options